### PR TITLE
a bunch of little bug fixes

### DIFF
--- a/RotationSolver.Basic/Actions/BaseAction_Target.cs
+++ b/RotationSolver.Basic/Actions/BaseAction_Target.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Logging;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
@@ -107,7 +108,8 @@ public partial class BaseAction
     /// <inheritdoc/>
     public bool FindTarget(bool mustUse, byte aoeCount, out BattleChara target, out BattleChara[] affectedTargets)
     {
-        aoeCount = Math.Max(aoeCount, mustUse ? (byte)1 : AOECount);
+        if (aoeCount == 0)
+            aoeCount = mustUse ? (byte)1 : AOECount;
 
         Position = Player.Object.Position;
         var player = Player.Object;
@@ -442,7 +444,7 @@ public partial class BaseAction
         if (!CanUseTo(b)) return false;
         if (ChoiceTarget(TargetFilterFuncEot(new BattleChara[] { b }, mustUse), mustUse) == null) return false;
 
-        if (IsSingleTarget)
+        if (IsSingleTarget || aoeCount == 1)
         {
             if (!mustUse)
             {

--- a/RotationSolver.Basic/Actions/BaseAction_Target.cs
+++ b/RotationSolver.Basic/Actions/BaseAction_Target.cs
@@ -1,5 +1,4 @@
 ﻿using Dalamud.Game.ClientState.Objects.SubKinds;
-using Dalamud.Logging;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;

--- a/RotationSolver.Basic/Helpers/TargetFilter.cs
+++ b/RotationSolver.Basic/Helpers/TargetFilter.cs
@@ -182,10 +182,6 @@ public static class TargetFilter
 
         var targets = inputCharas.Where(target =>
         {
-            if ((target.TargetObject?.FateId() ?? 0) != 0) {
-                return false;
-            }
-
             //Removed the listed names.
             IEnumerable<string> names = Array.Empty<string>();
             if (OtherConfiguration.NoProvokeNames.TryGetValue(Svc.ClientState.TerritoryType, out var ns1))

--- a/RotationSolver.Basic/Helpers/TargetFilter.cs
+++ b/RotationSolver.Basic/Helpers/TargetFilter.cs
@@ -182,6 +182,10 @@ public static class TargetFilter
 
         var targets = inputCharas.Where(target =>
         {
+            if ((target.TargetObject?.FateId() ?? 0) != 0) {
+                return false;
+            }
+
             //Removed the listed names.
             IEnumerable<string> names = Array.Empty<string>();
             if (OtherConfiguration.NoProvokeNames.TryGetValue(Svc.ClientState.TerritoryType, out var ns1))

--- a/RotationSolver.Basic/Rotations/Basic/BLU_Base.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BLU_Base.cs
@@ -185,7 +185,7 @@ public abstract class BLU_Base : CustomRotation
             act = null;
 
             if (!OnSlot) return false;
-            return base.CanUse(out act, option | CanUseOption.IgnoreClippingCheck, gcdCountForAbility);
+            return base.CanUse(out act, option | CanUseOption.IgnoreClippingCheck, aoeCount, gcdCountForAbility);
         }
     }
 

--- a/RotationSolver.Basic/Rotations/Basic/SAM_Base.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SAM_Base.cs
@@ -156,7 +156,6 @@ public abstract class SAM_Base : CustomRotation
     public static IBaseAction OgiNamikiri { get; } = new BaseAction(ActionID.OgiNamikiri)
     {
         StatusNeed = new[] { StatusID.OgiNamikiriReady },
-        ActionCheck = (b, m) => !IsMoving
     };
 
     /// <summary>
@@ -174,7 +173,7 @@ public abstract class SAM_Base : CustomRotation
     /// </summary>
     public static IBaseAction Higanbana { get; } = new BaseAction(ActionID.Higanbana, ActionOption.Dot | ActionOption.UseResources)
     {
-        ActionCheck = (b, m) => !IsMoving && SenCount == 1,
+        ActionCheck = (b, m) => SenCount == 1,
         TargetStatus = new[] { StatusID.Higanbana },
     };
 
@@ -183,7 +182,7 @@ public abstract class SAM_Base : CustomRotation
     /// </summary>
     public static IBaseAction TenkaGoken { get; } = new BaseAction(ActionID.TenkaGoken, ActionOption.UseResources)
     {
-        ActionCheck = (b, m) => !IsMoving && SenCount == 2,
+        ActionCheck = (b, m) => SenCount == 2,
     };
 
     /// <summary>
@@ -191,7 +190,7 @@ public abstract class SAM_Base : CustomRotation
     /// </summary>
     public static IBaseAction MidareSetsugekka { get; } = new BaseAction(ActionID.MidareSetsugekka, ActionOption.UseResources)
     {
-        ActionCheck = (b, m) => !IsMoving && SenCount == 3,
+        ActionCheck = (b, m) => SenCount == 3,
     };
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -129,7 +129,7 @@ public abstract partial class CustomRotation
     /// 
     /// </summary>
     public static IBaseAction Reprisal { get; } = new RoleAction(ActionID.Reprisal, new JobRole[] { JobRole.Tank }) {
-        FilterForHostiles = b => b.Where(tar => !tar.HasStatus(false, (StatusID)1193))
+        TargetStatus = new[] { (StatusID)1193 },
     };
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -1,4 +1,4 @@
-﻿using ECommons.ExcelServices;
+using ECommons.ExcelServices;
 using RotationSolver.Basic.Traits;
 
 namespace RotationSolver.Basic.Rotations;
@@ -128,7 +128,9 @@ public abstract partial class CustomRotation
     /// <summary>
     /// 
     /// </summary>
-    public static IBaseAction Reprisal { get; } = new RoleAction(ActionID.Reprisal, new JobRole[] { JobRole.Tank });
+    public static IBaseAction Reprisal { get; } = new RoleAction(ActionID.Reprisal, new JobRole[] { JobRole.Tank }) {
+        FilterForHostiles = b => b.Where(tar => !tar.HasStatus(false, (StatusID)1193))
+    };
 
     /// <summary>
     /// 

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -129,7 +129,7 @@ public abstract partial class CustomRotation
     /// 
     /// </summary>
     public static IBaseAction Reprisal { get; } = new RoleAction(ActionID.Reprisal, new JobRole[] { JobRole.Tank }) {
-        TargetStatus = new[] { (StatusID)1193 },
+        FilterForHostiles = b => b.Where(tar => !tar.HasStatus(false, (StatusID)1193))
     };
 
     /// <summary>


### PR DESCRIPTION
* aoeCount is now checked properly if the rotation overrides it
* BLU_Base passes aoeCount correctly
* Removed `IsMoving` checks from SAM_Base because the cast time restriction already does that
* add target filter to Reprisal to prevent overwriting another player's