### PR TITLE
Pass hostiles list to DefenseArea and DefenseSingle methods

### DIFF
--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -296,6 +296,14 @@ internal static class DataCenter
     () => (Service.Config.GetValue(PluginConfigFloat.HostileDelayMin),
     Service.Config.GetValue(PluginConfigFloat.HostileDelayMax)));
 
+    public static ObjectListDelay<BattleChara> HostileTargetsCastingAOE { get; } = new ObjectListDelay<BattleChara>(
+    () => (Service.Config.GetValue(PluginConfigFloat.HostileDelayMin),
+    Service.Config.GetValue(PluginConfigFloat.HostileDelayMax)));
+
+    public static ObjectListDelay<BattleChara> HostileTargetsCastingToTank { get; } = new ObjectListDelay<BattleChara>(
+    () => (Service.Config.GetValue(PluginConfigFloat.HostileDelayMin),
+    Service.Config.GetValue(PluginConfigFloat.HostileDelayMax)));
+
     public static IEnumerable<BattleChara> AllHostileTargets { get; internal set; } = Array.Empty<BattleChara>();
 
     public static IEnumerable<BattleChara> TarOnMeTargets { get; internal set; } = Array.Empty<BattleChara>();

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -296,13 +296,9 @@ internal static class DataCenter
     () => (Service.Config.GetValue(PluginConfigFloat.HostileDelayMin),
     Service.Config.GetValue(PluginConfigFloat.HostileDelayMax)));
 
-    public static ObjectListDelay<BattleChara> HostileTargetsCastingAOE { get; } = new ObjectListDelay<BattleChara>(
-    () => (Service.Config.GetValue(PluginConfigFloat.HostileDelayMin),
-    Service.Config.GetValue(PluginConfigFloat.HostileDelayMax)));
+    public static IEnumerable<BattleChara> HostileTargetsCastingAOE { get; internal set; } = Array.Empty<BattleChara>();
 
-    public static ObjectListDelay<BattleChara> HostileTargetsCastingToTank { get; } = new ObjectListDelay<BattleChara>(
-    () => (Service.Config.GetValue(PluginConfigFloat.HostileDelayMin),
-    Service.Config.GetValue(PluginConfigFloat.HostileDelayMax)));
+    public static IEnumerable<BattleChara> HostileTargetsCastingToTank { get; internal set; } = Array.Empty<BattleChara>();
 
     public static IEnumerable<BattleChara> AllHostileTargets { get; internal set; } = Array.Empty<BattleChara>();
 

--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -134,6 +134,11 @@ public static class ObjectHelper
         return _effectRangeCheck[id] = true;
     }
 
+    public static float RemainingCastTime(this BattleChara b)
+    {
+        return b.IsCasting ? b.TotalCastTime - b.CurrentCastTime : 999.99f;
+    }
+
     /// <summary>
     /// Is object a dummy.
     /// </summary>

--- a/RotationSolver.Basic/Rotations/Basic/SAM_Base.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SAM_Base.cs
@@ -389,9 +389,12 @@ public abstract class SAM_Base : CustomRotation
 
     /// <inheritdoc/>
     [RotationDesc(ActionID.ThirdEye)]
-    protected override bool DefenseSingleAbility(out IAction act)
+    protected override bool DefenseSingleAbility(out IAction act, IEnumerable<BattleChara> hostiles)
     {
-        if (ThirdEye.CanUse(out act)) return true;
+        // Third Eye's buff duration is 4s
+        if (!hostiles.Any() || hostiles.Any(h => h.RemainingCastTime() < 4))
+            if (ThirdEye.CanUse(out act))
+                return true;
         return base.DefenseSingleAbility(out act);
     }
 }

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -348,7 +348,7 @@ public abstract partial class CustomRotation
     /// The ability that defenses single character.
     /// </summary>
     /// <param name="act">Result action.</param>
-    /// <param name="hostiles">Hostiles casting single-target actions/tankbusters. Empty during a forced DefenseSingle window.</param>
+    /// <param name="hostiles">Hostiles casting single-target actions (tankbusters). If the player is on a DPS job, this list may also include hostiles casting AOE actions (raidwides). Empty during a forced DefenseSingle window.</param>
     /// <returns>Can we use it.</returns>
     [RotationDesc(DescType.DefenseSingleAbility)]
     protected virtual bool DefenseSingleAbility(out IAction act, IEnumerable<BattleChara> hostiles)

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -4,7 +4,7 @@ namespace RotationSolver.Basic.Rotations;
 
 public abstract partial class CustomRotation
 {
-    private bool Ability(IAction nextGCD, out IAction act, bool helpDefenseAOE, bool helpDefenseSingle)
+    private bool Ability(IAction nextGCD, out IAction act, IEnumerable<BattleChara> hostilesCastingAOE, IEnumerable<BattleChara> hostilesCastingST)
     {
         act = DataCenter.CommandNextAction;
 
@@ -39,7 +39,7 @@ public abstract partial class CustomRotation
         if (GeneralHealAbility(out act)) return true;
         if (DataCenter.IsSpeed && SpeedAbility(out act)) return true;
 
-        if (AutoDefense(role, helpDefenseAOE, helpDefenseSingle, out act)) return true;
+        if (AutoDefense(role, hostilesCastingAOE, hostilesCastingST, out act)) return true;
 
         BaseAction.OtherOption |= CanUseOption.EmptyOrSkipCombo;
         if (MovingAbility(out act)) return true;
@@ -138,8 +138,8 @@ public abstract partial class CustomRotation
         act = null;
 
         BaseAction.OtherOption |= CanUseOption.MustUse;
-        if (DataCenter.IsDefenseArea && DefenseAreaAbility(out act)) return true;
-        if (DataCenter.IsDefenseSingle && DefenseSingleAbility(out act)) return true;
+        if (DataCenter.IsDefenseArea && DefenseAreaAbility(out act, Array.Empty<BattleChara>())) return true;
+        if (DataCenter.IsDefenseSingle && DefenseSingleAbility(out act, Array.Empty<BattleChara>())) return true;
 
         BaseAction.OtherOption &= ~CanUseOption.MustUse;
 
@@ -169,7 +169,7 @@ public abstract partial class CustomRotation
         return false;
     }
 
-    private bool AutoDefense(JobRole role, bool helpDefenseAOE, bool helpDefenseSingle, out IAction act)
+    private bool AutoDefense(JobRole role, IEnumerable<BattleChara> hostilesCastingAOE, IEnumerable<BattleChara> hostilesCastingST, out IAction act)
     {
         act = null;
         if (!InCombat || !HasHostilesInRange)
@@ -191,12 +191,12 @@ public abstract partial class CustomRotation
         //No using defense abilities.
         if (!Service.Config.GetValue(PluginConfigBool.UseDefenseAbility)) return false;
 
-        if (helpDefenseAOE)
+        if (hostilesCastingAOE.Any())
         {
-            if (DefenseAreaAbility(out act)) return true;
+            if (DefenseAreaAbility(out act, hostilesCastingAOE)) return true;
             if (role is JobRole.Melee or JobRole.RangedPhysical or JobRole.RangedMagical)
             {
-                if (DefenseSingleAbility(out act)) return true;
+                if (DefenseSingleAbility(out act, hostilesCastingAOE)) return true;
             }
         }
 
@@ -215,18 +215,18 @@ public abstract partial class CustomRotation
                 && Player.GetHealthRatio() <= Service.Config.GetValue(DataCenter.Job, JobConfigFloat.HealthForAutoDefense)
                 && movingHere && attacked)
             {
-                if (DefenseSingleAbility(out act)) return true;
+                if (DefenseSingleAbility(out act, hostilesCastingST)) return true;
                 if (ArmsLength.CanUse(out act)) return true;
             }
 
             //Big damage casting action.
             if (DataCenter.IsHostileCastingToTank)
             {
-                if (DefenseSingleAbility(out act)) return true;
+                if (DefenseSingleAbility(out act, hostilesCastingST)) return true;
             }
         }
 
-        if (helpDefenseSingle && DefenseSingleAbility(out act)) return true;
+        if (hostilesCastingST.Any() && DefenseSingleAbility(out act, hostilesCastingST)) return true;
 
         return false;
     }
@@ -348,9 +348,35 @@ public abstract partial class CustomRotation
     /// The ability that defenses single character.
     /// </summary>
     /// <param name="act">Result action.</param>
+    /// <param name="hostiles">Hostiles casting single-target actions/tankbusters. May be empty, e.g. during a forced DefenseSingle window.</param>
     /// <returns>Can we use it.</returns>
     [RotationDesc(DescType.DefenseSingleAbility)]
+    protected virtual bool DefenseSingleAbility(out IAction act, IEnumerable<BattleChara> hostiles)
+    {
+        act = null; return false;
+    }
+
+    /// <summary>
+    /// The ability that defenses single character.
+    /// </summary>
+    /// <param name="act">Result action.</param>
+    /// <returns>Can we use it.</returns>
+    [Obsolete("Use DefenseSingleAbility(act, hostiles)")]
+    [RotationDesc(DescType.DefenseSingleAbility)]
     protected virtual bool DefenseSingleAbility(out IAction act)
+    {
+        return DefenseSingleAbility(out act, Array.Empty<BattleChara>());
+    }
+
+    /// <summary>
+    /// The ability that defense area.
+    /// </summary>
+    /// <param name="act">Result action.</param>
+    /// <param name="hostiles">Hostiles casting AOE actions. May be empty, e.g. during a forced DefenseArea window.</param>
+    /// <returns>Can we use it.</returns>
+
+    [RotationDesc(DescType.DefenseAreaAbility)]
+    protected virtual bool DefenseAreaAbility(out IAction act, IEnumerable<BattleChara> hostiles)
     {
         act = null; return false;
     }
@@ -361,10 +387,11 @@ public abstract partial class CustomRotation
     /// <param name="act">Result action.</param>
     /// <returns>Can we use it.</returns>
 
+    [Obsolete("Use DefenseAreaAbility(act, hostiles)")]
     [RotationDesc(DescType.DefenseAreaAbility)]
     protected virtual bool DefenseAreaAbility(out IAction act)
     {
-        act = null; return false;
+        return DefenseAreaAbility(out act, Array.Empty<BattleChara>());
     }
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -1,4 +1,5 @@
-﻿using RotationSolver.Basic.Configuration;
+﻿using Dalamud.Logging;
+using RotationSolver.Basic.Configuration;
 
 namespace RotationSolver.Basic.Rotations;
 
@@ -348,12 +349,12 @@ public abstract partial class CustomRotation
     /// The ability that defenses single character.
     /// </summary>
     /// <param name="act">Result action.</param>
-    /// <param name="hostiles">Hostiles casting single-target actions/tankbusters. May be empty, e.g. during a forced DefenseSingle window.</param>
+    /// <param name="hostiles">Hostiles casting single-target actions/tankbusters. Empty during a forced DefenseSingle window.</param>
     /// <returns>Can we use it.</returns>
     [RotationDesc(DescType.DefenseSingleAbility)]
     protected virtual bool DefenseSingleAbility(out IAction act, IEnumerable<BattleChara> hostiles)
     {
-        act = null; return false;
+        return DefenseSingleAbility(out act);
     }
 
     /// <summary>
@@ -361,22 +362,8 @@ public abstract partial class CustomRotation
     /// </summary>
     /// <param name="act">Result action.</param>
     /// <returns>Can we use it.</returns>
-    [Obsolete("Use DefenseSingleAbility(act, hostiles)")]
     [RotationDesc(DescType.DefenseSingleAbility)]
     protected virtual bool DefenseSingleAbility(out IAction act)
-    {
-        return DefenseSingleAbility(out act, Array.Empty<BattleChara>());
-    }
-
-    /// <summary>
-    /// The ability that defense area.
-    /// </summary>
-    /// <param name="act">Result action.</param>
-    /// <param name="hostiles">Hostiles casting AOE actions. May be empty, e.g. during a forced DefenseArea window.</param>
-    /// <returns>Can we use it.</returns>
-
-    [RotationDesc(DescType.DefenseAreaAbility)]
-    protected virtual bool DefenseAreaAbility(out IAction act, IEnumerable<BattleChara> hostiles)
     {
         act = null; return false;
     }
@@ -385,13 +372,25 @@ public abstract partial class CustomRotation
     /// The ability that defense area.
     /// </summary>
     /// <param name="act">Result action.</param>
+    /// <param name="hostiles">Hostiles casting AOE actions. Empty during a forced DefenseArea window.</param>
     /// <returns>Can we use it.</returns>
 
-    [Obsolete("Use DefenseAreaAbility(act, hostiles)")]
+    [RotationDesc(DescType.DefenseAreaAbility)]
+    protected virtual bool DefenseAreaAbility(out IAction act, IEnumerable<BattleChara> hostiles)
+    {
+        return DefenseAreaAbility(out act);
+    }
+
+    /// <summary>
+    /// The ability that defense area.
+    /// </summary>
+    /// <param name="act">Result action.</param>
+    /// <returns>Can we use it.</returns>
+
     [RotationDesc(DescType.DefenseAreaAbility)]
     protected virtual bool DefenseAreaAbility(out IAction act)
     {
-        return DefenseAreaAbility(out act, Array.Empty<BattleChara>());
+        act = null; return false;
     }
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -215,7 +215,7 @@ public abstract partial class CustomRotation
                 && Player.GetHealthRatio() <= Service.Config.GetValue(DataCenter.Job, JobConfigFloat.HealthForAutoDefense)
                 && movingHere && attacked)
             {
-                if (DefenseSingleAbility(out act, hostilesCastingST)) return true;
+                if (DefenseSingleAbility(out act, Array.Empty<BattleChara>())) return true;
                 if (ArmsLength.CanUse(out act)) return true;
             }
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -1,5 +1,4 @@
-﻿using Dalamud.Logging;
-using RotationSolver.Basic.Configuration;
+﻿using RotationSolver.Basic.Configuration;
 
 namespace RotationSolver.Basic.Rotations;
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -1,4 +1,5 @@
-﻿using RotationSolver.Basic.Configuration;
+﻿using Dalamud.Logging;
+using RotationSolver.Basic.Configuration;
 
 namespace RotationSolver.Basic.Rotations;
 
@@ -255,9 +256,7 @@ public abstract partial class CustomRotation
     [RotationDesc(DescType.DefenseSingleGCD)]
     protected virtual bool DefenseSingleGCD(out IAction act, IEnumerable<BattleChara> hostiles)
     {
-        if (LostStoneskin.CanUse(out act)) return true;
-
-        act = null; return false;
+        return DefenseSingleGCD(out act);
     }
 
     /// <summary>
@@ -265,11 +264,12 @@ public abstract partial class CustomRotation
     /// </summary>
     /// <param name="act"></param>
     /// <returns></returns>
-    [Obsolete("Use DefenseSingleGCD(act, hostiles)")]
     [RotationDesc(DescType.DefenseSingleGCD)]
     protected virtual bool DefenseSingleGCD(out IAction act)
     {
-        return DefenseSingleGCD(out act, Array.Empty<BattleChara>());
+        if (LostStoneskin.CanUse(out act)) return true;
+
+        act = null; return false;
     }
 
 
@@ -282,9 +282,7 @@ public abstract partial class CustomRotation
     [RotationDesc(DescType.DefenseAreaGCD)]
     protected virtual bool DefenseAreaGCD(out IAction act, IEnumerable<BattleChara> hostiles)
     {
-        if (LostStoneskin2.CanUse(out act)) return true;
-
-        act = null; return false;
+        return DefenseAreaGCD(out act);
     }
 
     /// <summary>
@@ -292,11 +290,12 @@ public abstract partial class CustomRotation
     /// </summary>
     /// <param name="act"></param>
     /// <returns></returns>
-    [Obsolete("Use DefenseAreaGCD(act, hostiles)")]
     [RotationDesc(DescType.DefenseAreaGCD)]
     protected virtual bool DefenseAreaGCD(out IAction act)
     {
-        return DefenseAreaGCD(out act, Array.Empty<BattleChara>());
+        if (LostStoneskin2.CanUse(out act)) return true;
+
+        act = null; return false;
     }
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -5,7 +5,7 @@ namespace RotationSolver.Basic.Rotations;
 public abstract partial class CustomRotation
 {
     private static DateTime _nextTimeToHeal = DateTime.MinValue;
-    private IAction GCD(bool helpDefenseAOE, bool helpDefenseSingle)
+    private IAction GCD(IEnumerable<BattleChara> hostilesCastingAOE, IEnumerable<BattleChara> hostilesCastingST)
     {
         IAction act = DataCenter.CommandNextAction;
 
@@ -49,12 +49,12 @@ public abstract partial class CustomRotation
                 BaseAction.AutoHealCheck = false;
             }
         }
-        if (IsDefenseArea && DefenseAreaGCD(out act)) return act;
-        if (IsDefenseSingle && DefenseSingleGCD(out act)) return act;
+        if (IsDefenseArea && DefenseAreaGCD(out act, Array.Empty<BattleChara>())) return act;
+        if (IsDefenseSingle && DefenseSingleGCD(out act, Array.Empty<BattleChara>())) return act;
 
         //Auto Defense
-        if (DataCenter.SetAutoStatus(AutoStatus.DefenseArea, helpDefenseAOE) && DefenseAreaGCD(out act)) return act;
-        if (DataCenter.SetAutoStatus(AutoStatus.DefenseSingle, helpDefenseSingle) && DefenseSingleGCD(out act)) return act;
+        if (DataCenter.SetAutoStatus(AutoStatus.DefenseArea, hostilesCastingAOE.Any()) && DefenseAreaGCD(out act, hostilesCastingAOE)) return act;
+        if (DataCenter.SetAutoStatus(AutoStatus.DefenseSingle, hostilesCastingST.Any()) && DefenseSingleGCD(out act, hostilesCastingST)) return act;
 
         //Esuna
         if (DataCenter.SetAutoStatus(AutoStatus.Esuna, (IsEsunaStanceNorth
@@ -250,11 +250,39 @@ public abstract partial class CustomRotation
     /// Defense single gcd.
     /// </summary>
     /// <param name="act"></param>
+    /// <param name="hostiles">The attacking hostiles.</param>
     /// <returns></returns>
+    [RotationDesc(DescType.DefenseSingleGCD)]
+    protected virtual bool DefenseSingleGCD(out IAction act, IEnumerable<BattleChara> hostiles)
+    {
+        if (LostStoneskin.CanUse(out act)) return true;
+
+        act = null; return false;
+    }
+
+    /// <summary>
+    /// Defense single gcd.
+    /// </summary>
+    /// <param name="act"></param>
+    /// <returns></returns>
+    [Obsolete("Use DefenseSingleGCD(act, hostiles)")]
     [RotationDesc(DescType.DefenseSingleGCD)]
     protected virtual bool DefenseSingleGCD(out IAction act)
     {
-        if (LostStoneskin.CanUse(out act)) return true;
+        return DefenseSingleGCD(out act, Array.Empty<BattleChara>());
+    }
+
+
+    /// <summary>
+    /// Defense area gcd.
+    /// </summary>
+    /// <param name="act"></param>
+    /// <param name="hostiles">The attacking hostiles.</param>
+    /// <returns></returns>
+    [RotationDesc(DescType.DefenseAreaGCD)]
+    protected virtual bool DefenseAreaGCD(out IAction act, IEnumerable<BattleChara> hostiles)
+    {
+        if (LostStoneskin2.CanUse(out act)) return true;
 
         act = null; return false;
     }
@@ -264,12 +292,11 @@ public abstract partial class CustomRotation
     /// </summary>
     /// <param name="act"></param>
     /// <returns></returns>
+    [Obsolete("Use DefenseAreaGCD(act, hostiles)")]
     [RotationDesc(DescType.DefenseAreaGCD)]
     protected virtual bool DefenseAreaGCD(out IAction act)
     {
-        if (LostStoneskin2.CanUse(out act)) return true;
-
-        act = null; return false;
+        return DefenseAreaGCD(out act, Array.Empty<BattleChara>());
     }
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -1,5 +1,4 @@
-﻿using Dalamud.Logging;
-using RotationSolver.Basic.Configuration;
+﻿using RotationSolver.Basic.Configuration;
 
 namespace RotationSolver.Basic.Rotations;
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_Invoke.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Invoke.cs
@@ -179,7 +179,7 @@ public abstract partial class CustomRotation
             ? DataCenter.HostileTargetsCastingAOE.AsEnumerable()
             : Array.Empty<BattleChara>();
 
-        IEnumerable<BattleChara> hostilesCastingST = null;
+        IEnumerable<BattleChara> hostilesCastingST = Array.Empty<BattleChara>();
         if (ClassJob.GetJobRole() == JobRole.Healer || ClassJob.RowId == (uint)ECommons.ExcelServices.Job.PLD)
         {
             hostilesCastingST = DataCenter.HostileTargetsCastingToTank.IntersectBy(

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.SubKinds;
-using Dalamud.Logging;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -62,6 +62,7 @@ internal static partial class TargetUpdater
         DataCenter.WeakenPeople.Delay(empty);
         DataCenter.HostileTargets.Delay(empty);
         DataCenter.HostileTargetsCastingAOE.Delay(empty);
+        DataCenter.HostileTargetsCastingToTank.Delay(empty);
         DataCenter.CanInterruptTargets.Delay(empty);
     }
 

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Logging;
 using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
@@ -55,14 +56,14 @@ internal static partial class TargetUpdater
             = DataCenter.AllianceMembers
             = DataCenter.AllianceTanks
             = DataCenter.DyingPeople
+            = DataCenter.HostileTargetsCastingAOE
+            = DataCenter.HostileTargetsCastingToTank
             = empty;
 
         DataCenter.DeathPeopleAll.Delay(empty);
         DataCenter.DeathPeopleParty.Delay(empty);
         DataCenter.WeakenPeople.Delay(empty);
         DataCenter.HostileTargets.Delay(empty);
-        DataCenter.HostileTargetsCastingAOE.Delay(empty);
-        DataCenter.HostileTargetsCastingToTank.Delay(empty);
         DataCenter.CanInterruptTargets.Delay(empty);
     }
 
@@ -157,8 +158,8 @@ internal static partial class TargetUpdater
         DataCenter.MobsTime = DataCenter.HostileTargets.Count(o => o.DistanceToPlayer() <= JobRange && o.CanSee())
             >= Service.Config.GetValue(PluginConfigInt.AutoDefenseNumber);
 
-        DataCenter.HostileTargetsCastingToTank.Delay(DataCenter.HostileTargets.Where(IsHostileCastingTank));
-        DataCenter.HostileTargetsCastingAOE.Delay(DataCenter.HostileTargets.Where(IsHostileCastingArea));
+        DataCenter.HostileTargetsCastingToTank = DataCenter.HostileTargets.Where(IsHostileCastingTank);
+        DataCenter.HostileTargetsCastingAOE = DataCenter.HostileTargets.Where(IsHostileCastingArea);
 
         DataCenter.IsHostileCastingToTank = IsCastingTankVfx() || DataCenter.HostileTargetsCastingToTank.Any();
         DataCenter.IsHostileCastingAOE = IsCastingAreaVfx() || DataCenter.HostileTargetsCastingAOE.Any();

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -61,6 +61,7 @@ internal static partial class TargetUpdater
         DataCenter.DeathPeopleParty.Delay(empty);
         DataCenter.WeakenPeople.Delay(empty);
         DataCenter.HostileTargets.Delay(empty);
+        DataCenter.HostileTargetsCastingAOE.Delay(empty);
         DataCenter.CanInterruptTargets.Delay(empty);
     }
 
@@ -155,8 +156,11 @@ internal static partial class TargetUpdater
         DataCenter.MobsTime = DataCenter.HostileTargets.Count(o => o.DistanceToPlayer() <= JobRange && o.CanSee())
             >= Service.Config.GetValue(PluginConfigInt.AutoDefenseNumber);
 
-        DataCenter.IsHostileCastingToTank = IsCastingTankVfx() || DataCenter.HostileTargets.Any(IsHostileCastingTank);
-        DataCenter.IsHostileCastingAOE = IsCastingAreaVfx() || DataCenter.HostileTargets.Any(IsHostileCastingArea);
+        DataCenter.HostileTargetsCastingToTank.Delay(DataCenter.HostileTargets.Where(IsHostileCastingTank));
+        DataCenter.HostileTargetsCastingAOE.Delay(DataCenter.HostileTargets.Where(IsHostileCastingArea));
+
+        DataCenter.IsHostileCastingToTank = IsCastingTankVfx() || DataCenter.HostileTargetsCastingToTank.Any();
+        DataCenter.IsHostileCastingAOE = IsCastingAreaVfx() || DataCenter.HostileTargetsCastingAOE.Any();
 
         DataCenter.CanProvoke = _provokeDelay.Delay(TargetFilter.ProvokeTarget(DataCenter.HostileTargets, true).Count() != DataCenter.HostileTargets.Count());
     }


### PR DESCRIPTION
This will make it easier for rotations to make mit decisions based on what enemies are doing.

### Motivation

Third Eye has a very short buff duration (4s) and plenty of raidwides have a long enough cast bar that Third Eye expires if it was used as soon as the boss started casting. I noticed this in P12S.

This could be fixed in the SAM rotation by checking whether the hostile target's cast bar has less than 4 seconds remaining, but finding the right hostile target would require extra work. RS is already doing that work, so why not provide it to the rotation lib too?

This might also make detecting stuff like paired tankbusters easier for healers but I haven't experimented with it much yet.