### PR TITLE
Better support for several Lost Actions

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -357,6 +357,12 @@ public enum PluginConfigBool : byte
     [Default(false)] TargetAllForFriendly,
     [Default(false)] ShowCooldownWindow,
 
+    [Default(true)] UseLostActions,
+    [Default(true)] UseLostFlareStarOnBosses,
+    [Default(false)] UseLostFlareStarOnMobs,
+    [Default(true)] UseLostAssassinationOnMobs,
+    [Default(true)] LostReflectAutoRefresh,
+
     [Default(true)] RecordCastingArea,
 
     [Default(true)] AutoOffAfterCombat,
@@ -443,6 +449,7 @@ public enum PluginConfigFloat : byte
     [Default(24f, 0f, 90f), Unit(ConfigUnitType.Degree)] MoveTargetAngle,
     [Default(90f, 10f, 1800f), Unit(ConfigUnitType.Seconds)] BossTimeToKill,
     [Default(10f, 0f, 60f), Unit(ConfigUnitType.Seconds)] DyingTimeToKill,
+    [Default(15f, 0f, 1800f), Unit(ConfigUnitType.Seconds)] LostAssassinationTimeToKill,
 
     [Default(16f, 9.6f, 96f), Unit(ConfigUnitType.Pixels)] CooldownFontSize,
 

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -358,7 +358,6 @@ public enum PluginConfigBool : byte
     [Default(false)] ShowCooldownWindow,
 
     [Default(true)] UseLostActions,
-    [Default(true)] UseLostFlareStarOnBosses,
     [Default(false)] UseLostFlareStarOnMobs,
     [Default(true)] UseLostAssassinationOnMobs,
     [Default(true)] LostReflectAutoRefresh,

--- a/RotationSolver.Basic/Configuration/OtherConfiguration.cs
+++ b/RotationSolver.Basic/Configuration/OtherConfiguration.cs
@@ -48,6 +48,9 @@ public class OtherConfiguration
         { (uint) ActionID.SteelCyclone, 2},
         { (uint) ActionID.VariantSpiritDart, 1 },
         { (uint) ActionID.VariantSpiritDart2, 1 },
+        { (uint) ActionID.LostRampage, 1 },
+        { (uint) ActionID.LostBurst, 1 },
+        { (uint) ActionID.LostFlarestar, 1 }
     };
 
     public static Dictionary<uint, float> ActionTTK = new()

--- a/RotationSolver.Basic/Data/ActionID.cs
+++ b/RotationSolver.Basic/Data/ActionID.cs
@@ -5211,17 +5211,37 @@ public enum ActionID : uint
     /// <summary>
     /// 
     /// </summary>
-    LostBravery = 20713,
-
-    /// <summary>
-    /// 
-    /// </summary>
     LostProtect = 20719,
 
     /// <summary>
     /// 
     /// </summary>
     LostShell = 20710,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    LostReflect = 20711,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    LostBravery = 20713,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    LostFontOfPower = 20717,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    BannerOfHonoredSacrifice = 20721,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    LostAssassination = 23914,
 
     /// <summary>
     /// 

--- a/RotationSolver.Basic/Data/StatusID.cs
+++ b/RotationSolver.Basic/Data/StatusID.cs
@@ -1336,12 +1336,22 @@ public enum StatusID : ushort
     /// <summary>
     /// 
     /// </summary>
-    LostSpellforge = 2338,
+    SpiritOfTheBeast = 2324,
 
     /// <summary>
     /// 
     /// </summary>
-    MagicalAversion = 2370,
+    BannerOfHonoredSacrifice = 2327,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    LostReflect = 2337,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    LostSpellforge = 2338,
 
     /// <summary>
     /// 
@@ -1351,7 +1361,17 @@ public enum StatusID : ushort
     /// <summary>
     /// 
     /// </summary>
+    LostFontOfPower = 2346,
+
+    /// <summary>
+    /// 
+    /// </summary>
     PhysicalAversion = 2369,
+
+    /// <summary>
+    /// 
+    /// </summary>
+    MagicalAversion = 2370,
 
     /// <summary>
     /// 

--- a/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Ability.cs
@@ -406,6 +406,7 @@ public abstract partial class CustomRotation
         if (VariantSpiritDart2.CanUse(out act, CanUseOption.MustUse)) return true;
         if (VariantRampart.CanUse(out act)) return true;
         if (VariantRampart2.CanUse(out act)) return true;
+        if (LostAssassination.CanUse(out act)) return true;
         return false;
     }
 }

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -448,7 +448,7 @@ public abstract partial class CustomRotation
     public static IBaseAction LostRampage { get; } = new RoleAction(
         ActionID.LostRampage,
         new JobRole[] { JobRole.Melee, JobRole.Tank, JobRole.RangedPhysical },
-        ActionOption.DutyAction
+        ActionOption.DutyAction | ActionOption.Eot
     ) {
         TargetStatus = new StatusID[] { StatusID.LostRampage },
         // TargetStatusIsGlobal = true,
@@ -463,7 +463,7 @@ public abstract partial class CustomRotation
     public static IBaseAction LostBurst { get; } = new RoleAction(
         ActionID.LostBurst,
         new JobRole[] { JobRole.Healer, JobRole.RangedMagical },
-        ActionOption.DutyAction
+        ActionOption.DutyAction | ActionOption.Eot
     ) {
         TargetStatus = new StatusID[] { StatusID.LostBurst },
         // TargetStatusIsGlobal = true,
@@ -578,7 +578,7 @@ public abstract partial class CustomRotation
     /// 
     /// </summary>
     public static IBaseAction LostFlarestar { get; } = new BaseAction(ActionID.LostFlarestar,
-    ActionOption.DutyAction)
+    ActionOption.DutyAction | ActionOption.Dot)
     {
         FilterForHostiles = (tars) => tars.Where(t => t.IsBossFromIcon() || Service.Config.GetValue(PluginConfigBool.UseLostFlareStarOnMobs)),
         TargetStatus = new StatusID[] { StatusID.LostFlarestar },

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -592,9 +592,8 @@ public abstract partial class CustomRotation
     /// </summary>
     public static IBaseAction LostReflect { get; } = new BaseAction(ActionID.LostReflect, ActionOption.DutyAction | ActionOption.Friendly) {
         ChoiceTarget = (tars, mustUse) => tars.FirstOrDefault(b =>
-            Service.Config.GetValue(PluginConfigBool.LostReflectAutoRefresh) &&
-                b.HasStatus(true, StatusID.LostReflect) &&
-                b.WillStatusEndGCD(1, 0, true, StatusID.LostReflect))
+            b.HasStatus(true, StatusID.LostReflect) &&
+            b.WillStatusEndGCD(1, 0, true, StatusID.LostReflect))
     };
 
     /// <summary>

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -1,5 +1,6 @@
 ﻿using ECommons.ExcelServices;
 using RotationSolver.Basic.Traits;
+using RotationSolver.Basic.Configuration;
 
 namespace RotationSolver.Basic.Rotations;
 
@@ -98,7 +99,7 @@ public abstract partial class CustomRotation
     public static IBaseAction SecondWind { get; } = new RoleAction(ActionID.SecondWind,
         new JobRole[] { JobRole.RangedPhysical, JobRole.Melee }, ActionOption.Heal)
     {
-        ActionCheck = (b, m) => Player?.GetHealthRatio() < Service.Config.GetValue(DataCenter.Job, Configuration.JobConfigFloat.HealthSingleAbility) && InCombat,
+        ActionCheck = (b, m) => Player?.GetHealthRatio() < Service.Config.GetValue(DataCenter.Job, JobConfigFloat.HealthSingleAbility) && InCombat,
     };
 
     /// <summary>
@@ -390,8 +391,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostSpellforge { get; } = new BaseAction(ActionID.LostSpellforge,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostSpellforge },
-        ActionCheck = (b, m) => LostSpellforge.Target?.HasStatus(false, StatusID.MagicalAversion) ?? false,
+        TargetStatus = new StatusID[] { StatusID.LostSpellforge },
+        // TargetStatusIsGlobal = true,
         ChoiceTarget = (targets, mustUse) => targets.FirstOrDefault(t => (Job)t.ClassJob.Id switch
         {
             Job.WAR
@@ -419,8 +420,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostSteelsting { get; } = new BaseAction(ActionID.LostSteelsting,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostSteelsting },
-        ActionCheck = (b, m) => LostSteelsting.Target?.HasStatus(false, StatusID.PhysicalAversion) ?? false,
+        TargetStatus = new StatusID[] { StatusID.LostSteelsting },
+        // TargetStatusIsGlobal = true,
         ChoiceTarget = (targets, mustUse) => targets.FirstOrDefault(t => (Job)t.ClassJob.Id switch
         {
             Job.WHM
@@ -444,21 +445,53 @@ public abstract partial class CustomRotation
     /// <summary>
     /// 
     /// </summary>
-    public static IBaseAction LostRampage { get; } = new BaseAction(ActionID.LostRampage,
-        ActionOption.DutyAction | ActionOption.Friendly)
-    {
-        StatusProvide = new StatusID[] { StatusID.LostRampage },
-        ActionCheck = (b, m) => LostRampage.Target?.HasStatus(false, StatusID.PhysicalAversion) ?? false,
+    public static IBaseAction LostRampage { get; } = new RoleAction(
+        ActionID.LostRampage,
+        new JobRole[] { JobRole.Melee, JobRole.Tank, JobRole.RangedPhysical },
+        ActionOption.DutyAction
+    ) {
+        TargetStatus = new StatusID[] { StatusID.LostRampage },
+        // TargetStatusIsGlobal = true,
+        FilterForHostiles = (targets) => targets.Where(tar =>
+            ObjectHelper.CanInterrupt(tar) ||
+            (tar.IsBossFromIcon() && tar.HasStatus(false, StatusID.PhysicalAversion)))
     };
 
     /// <summary>
     /// 
     /// </summary>
-    public static IBaseAction LostBurst { get; } = new BaseAction(ActionID.LostBurst,
-        ActionOption.DutyAction | ActionOption.Friendly)
-    {
-        StatusProvide = new StatusID[] { StatusID.LostBurst },
-        ActionCheck = (b, m) => LostBurst.Target?.HasStatus(false, StatusID.MagicalAversion) ?? false,
+    public static IBaseAction LostBurst { get; } = new RoleAction(
+        ActionID.LostBurst,
+        new JobRole[] { JobRole.Healer, JobRole.RangedMagical },
+        ActionOption.DutyAction
+    ) {
+        TargetStatus = new StatusID[] { StatusID.LostBurst },
+        // TargetStatusIsGlobal = true,
+        FilterForHostiles = (targets) => targets.Where(tar =>
+            ObjectHelper.CanInterrupt(tar) ||
+            (tar.IsBossFromIcon() && tar.HasStatus(false, StatusID.MagicalAversion))),
+    };
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static IBaseAction LostAssassination { get; } = new RoleAction(
+        ActionID.LostAssassination,
+        new JobRole[] { JobRole.Melee, JobRole.Tank, JobRole.RangedPhysical },
+        ActionOption.DutyAction
+    ) {
+        ActionCheck = (tar, mustUse) => {
+            if (tar.IsBossFromIcon()) {
+                // use for Lost Font of Power on bosses
+                return Player.HasStatus(true, StatusID.SpiritOfTheBeast) && !tar.IsDying();
+            } else if (Service.Config.GetValue(PluginConfigBool.UseLostAssassinationOnMobs)) {
+                // use to instakill tanky mobs
+                var ttk = Service.Config.GetValue(PluginConfigFloat.LostAssassinationTimeToKill);
+                return tar.FindEnemyPositional() == EnemyPositional.Rear && tar.GetTimeToKill(true) >= ttk;
+            }
+
+            return false;
+        }
     };
 
     /// <summary>
@@ -467,7 +500,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostBravery { get; } = new BaseAction(ActionID.LostBravery,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostBravery },
+        TargetStatus = new StatusID[] { StatusID.LostBravery },
+        // TargetStatusIsGlobal = true,
     };
 
     /// <summary>
@@ -476,7 +510,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostProtect { get; } = new BaseAction(ActionID.LostProtect,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostProtect, StatusID.LostProtect2 },
+        TargetStatus = new StatusID[] { StatusID.LostProtect, StatusID.LostProtect2 },
+        // TargetStatusIsGlobal = true,
     };
 
     /// <summary>
@@ -485,7 +520,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostShell { get; } = new BaseAction(ActionID.LostShell,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostShell, StatusID.LostShell2 },
+        TargetStatus = new StatusID[] { StatusID.LostShell, StatusID.LostShell2 },
+        // TargetStatusIsGlobal = true,
     };
 
     /// <summary>
@@ -494,7 +530,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostProtect2 { get; } = new BaseAction(ActionID.LostProtect2,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostProtect2 },
+        TargetStatus = new StatusID[] { StatusID.LostProtect2 },
+        // TargetStatusIsGlobal = true,
     };
 
     /// <summary>
@@ -503,7 +540,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostShell2 { get; } = new BaseAction(ActionID.LostShell2,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostShell2 },
+        TargetStatus = new StatusID[] { StatusID.LostShell2 },
+        // TargetStatusIsGlobal = true,
     };
 
     /// <summary>
@@ -512,7 +550,8 @@ public abstract partial class CustomRotation
     public static IBaseAction LostBubble { get; } = new BaseAction(ActionID.LostBubble,
         ActionOption.DutyAction | ActionOption.Friendly)
     {
-        StatusProvide = new StatusID[] { StatusID.LostBubble },
+        TargetStatus = new StatusID[] { StatusID.LostBubble },
+        // TargetStatusIsGlobal = true,
     };
 
     /// <summary>
@@ -522,7 +561,8 @@ public abstract partial class CustomRotation
         ActionOption.DutyAction | ActionOption.Defense)
     {
         ChoiceTarget = TargetFilter.FindAttackedTarget,
-        StatusProvide = new StatusID[] { StatusID.LostStoneskin },
+        TargetStatus = new StatusID[] { StatusID.LostStoneskin },
+        // TargetStatusIsGlobal = true,
     };
 
     /// <summary>
@@ -540,7 +580,21 @@ public abstract partial class CustomRotation
     public static IBaseAction LostFlarestar { get; } = new BaseAction(ActionID.LostFlarestar,
     ActionOption.DutyAction)
     {
-        StatusProvide = new StatusID[] { StatusID.LostFlarestar },
+        FilterForHostiles = (tars) => tars.Where(t =>
+            Service.Config.GetValue(PluginConfigBool.UseLostFlareStarOnMobs) ||
+            (t.IsBossFromIcon() && Service.Config.GetValue(PluginConfigBool.UseLostFlareStarOnBosses))),
+        TargetStatus = new StatusID[] { StatusID.LostFlarestar },
+        // TargetStatusIsGlobal = true,
+    };
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static IBaseAction LostReflect { get; } = new BaseAction(ActionID.LostReflect, ActionOption.DutyAction | ActionOption.Friendly) {
+        ChoiceTarget = (tars, mustUse) => tars.FirstOrDefault(b =>
+            Service.Config.GetValue(PluginConfigBool.LostReflectAutoRefresh) &&
+                b.HasStatus(true, StatusID.LostReflect) &&
+                b.WillStatusEndGCD(1, 0, true, StatusID.LostReflect))
     };
 
     /// <summary>
@@ -549,7 +603,21 @@ public abstract partial class CustomRotation
     public static IBaseAction LostSeraphStrike { get; } = new BaseAction(ActionID.LostSeraphStrike,
         ActionOption.DutyAction)
     {
-        StatusProvide = new StatusID[] { StatusID.LostSeraphStrike },
+        TargetStatus = new StatusID[] { StatusID.LostSeraphStrike },
+    };
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static IBaseAction LostFontOfPower { get; } = new BaseAction(ActionID.LostFontOfPower, ActionOption.DutyAction) {
+        StatusProvide = new StatusID[] { StatusID.LostFontOfPower },
+    };
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public static IBaseAction BannerOfHonoredSacrifice { get; } = new BaseAction(ActionID.BannerOfHonoredSacrifice, ActionOption.DutyAction) {
+        StatusProvide = new StatusID[] { StatusID.BannerOfHonoredSacrifice },
     };
     #endregion
 

--- a/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_Actions.cs
@@ -580,9 +580,7 @@ public abstract partial class CustomRotation
     public static IBaseAction LostFlarestar { get; } = new BaseAction(ActionID.LostFlarestar,
     ActionOption.DutyAction)
     {
-        FilterForHostiles = (tars) => tars.Where(t =>
-            Service.Config.GetValue(PluginConfigBool.UseLostFlareStarOnMobs) ||
-            (t.IsBossFromIcon() && Service.Config.GetValue(PluginConfigBool.UseLostFlareStarOnBosses))),
+        FilterForHostiles = (tars) => tars.Where(t => t.IsBossFromIcon() || Service.Config.GetValue(PluginConfigBool.UseLostFlareStarOnMobs)),
         TargetStatus = new StatusID[] { StatusID.LostFlarestar },
         // TargetStatusIsGlobal = true,
     };

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -183,22 +183,16 @@ public abstract partial class CustomRotation
     protected virtual bool EmergencyGCD(out IAction act)
     {
         #region Bozja
-        if (LostSpellforge.CanUse(out act)) return true;
-        if (LostSteelsting.CanUse(out act)) return true;
+        if (LostFlarestar.CanUse(out act)) return true;
         if (LostRampage.CanUse(out act)) return true;
         if (LostBurst.CanUse(out act)) return true;
-
+        if (LostReflect.CanUse(out act)) return true;
         if (LostBravery.CanUse(out act)) return true;
         if (LostBubble.CanUse(out act)) return true;
         if (LostShell2.CanUse(out act)) return true;
         if (LostShell.CanUse(out act)) return true;
         if (LostProtect2.CanUse(out act)) return true;
         if (LostProtect.CanUse(out act)) return true;
-
-        //Add your own logic here.
-        //if (LostFlarestar.CanUse(out act)) return true;
-        //if (LostSeraphStrike.CanUse(out act)) return true;
-
         #endregion
 
         #region PvP

--- a/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
+++ b/RotationSolver.Basic/Rotations/CustomRotation_GCD.cs
@@ -186,7 +186,7 @@ public abstract partial class CustomRotation
         if (LostFlarestar.CanUse(out act)) return true;
         if (LostRampage.CanUse(out act)) return true;
         if (LostBurst.CanUse(out act)) return true;
-        if (LostReflect.CanUse(out act)) return true;
+        if (Service.Config.GetValue(PluginConfigBool.LostReflectAutoRefresh) && LostReflect.CanUse(out act)) return true;
         if (LostBravery.CanUse(out act)) return true;
         if (LostBubble.CanUse(out act)) return true;
         if (LostShell2.CanUse(out act)) return true;

--- a/RotationSolver/Localization/ConfigTranslation.cs
+++ b/RotationSolver/Localization/ConfigTranslation.cs
@@ -118,6 +118,11 @@ internal static class ConfigTranslation
         PluginConfigBool.HealWhenNothingTodo => LocalizationManager.RightLang.ConfigWindow_Param_HealWhenNothingTodo,
         PluginConfigBool.UseResourcesAction => LocalizationManager.RightLang.ConfigWindow_Auto_UseResourcesAction,
         PluginConfigBool.OnlyHealSelfWhenNoHealer => LocalizationManager.RightLang.ConfigWindow_Auto_OnlyHealSelfWhenNoHealer,
+        PluginConfigBool.UseLostActions => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostActions,
+        PluginConfigBool.UseLostFlareStarOnBosses => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostFlareStarOnBosses,
+        PluginConfigBool.UseLostFlareStarOnMobs => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostFlareStarOnMobs,
+        PluginConfigBool.UseLostAssassinationOnMobs => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostAssassinationOnMobs,
+        PluginConfigBool.LostReflectAutoRefresh => LocalizationManager.RightLang.ConfigWindow_Auto_LostReflectAutoRefresh,
 
         // target
         PluginConfigBool.AddEnemyListToHostile => LocalizationManager.RightLang.ConfigWindow_Param_AddEnemyListToHostile,
@@ -204,6 +209,7 @@ internal static class ConfigTranslation
         PluginConfigFloat.AutoHealTimeToKill => LocalizationManager.RightLang.ConfigWindow_Auto_AutoHealTimeToKill,
         PluginConfigFloat.ProvokeDelayMin => LocalizationManager.RightLang.ConfigWindow_Auto_ProvokeDelay,
         PluginConfigFloat.HealthForGuard => LocalizationManager.RightLang.ConfigWindow_Param_HealthForGuard,
+        PluginConfigFloat.LostAssassinationTimeToKill => LocalizationManager.RightLang.ConfigWindow_Auto_LostAssassinationTimeToKill,
         // target
         PluginConfigFloat.BossTimeToKill => LocalizationManager.RightLang.ConfigWindow_Param_BossTimeToKill,
         PluginConfigFloat.DyingTimeToKill => LocalizationManager.RightLang.ConfigWindow_Param_DyingTimeToKill,

--- a/RotationSolver/Localization/ConfigTranslation.cs
+++ b/RotationSolver/Localization/ConfigTranslation.cs
@@ -119,7 +119,6 @@ internal static class ConfigTranslation
         PluginConfigBool.UseResourcesAction => LocalizationManager.RightLang.ConfigWindow_Auto_UseResourcesAction,
         PluginConfigBool.OnlyHealSelfWhenNoHealer => LocalizationManager.RightLang.ConfigWindow_Auto_OnlyHealSelfWhenNoHealer,
         PluginConfigBool.UseLostActions => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostActions,
-        PluginConfigBool.UseLostFlareStarOnBosses => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostFlareStarOnBosses,
         PluginConfigBool.UseLostFlareStarOnMobs => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostFlareStarOnMobs,
         PluginConfigBool.UseLostAssassinationOnMobs => LocalizationManager.RightLang.ConfigWindow_Auto_UseLostAssassinationOnMobs,
         PluginConfigBool.LostReflectAutoRefresh => LocalizationManager.RightLang.ConfigWindow_Auto_LostReflectAutoRefresh,

--- a/RotationSolver/Localization/Strings.cs
+++ b/RotationSolver/Localization/Strings.cs
@@ -793,8 +793,7 @@ internal class Strings
     public string ConfigWindow_Auto_UseResourcesAction { get; set; } = "Use actions that use resources";
     public string ConfigWindow_Auto_OnlyHealSelfWhenNoHealer { get; set; } = "Only Heal self When Not a healer";
     public string ConfigWindow_Auto_UseLostActions { get; set; } = "Use Lost Actions (Bozja)";
-    public string ConfigWindow_Auto_UseLostFlareStarOnBosses { get; set; } = "Use Lost Flare Star on bosses";
-    public string ConfigWindow_Auto_UseLostFlareStarOnMobs { get; set; } = "Use Lost Flare Star on mobs";
+    public string ConfigWindow_Auto_UseLostFlareStarOnMobs { get; set; } = "Use Lost Flare Star on non-boss targets";
     public string ConfigWindow_Auto_UseLostAssassinationOnMobs { get; set; } = "Use Lost Assassination to kill non-boss targets";
     public string ConfigWindow_Auto_LostReflectAutoRefresh { get; set; } = "Automatically refresh Lost Reflect before it expires";
     public string ConfigWindow_Auto_LostAssassinationTimeToKill { get; set; } = "Expected TTK required to use Lost Assassination on target";

--- a/RotationSolver/Localization/Strings.cs
+++ b/RotationSolver/Localization/Strings.cs
@@ -792,6 +792,12 @@ internal class Strings
 
     public string ConfigWindow_Auto_UseResourcesAction { get; set; } = "Use actions that use resources";
     public string ConfigWindow_Auto_OnlyHealSelfWhenNoHealer { get; set; } = "Only Heal self When Not a healer";
+    public string ConfigWindow_Auto_UseLostActions { get; set; } = "Use Lost Actions (Bozja)";
+    public string ConfigWindow_Auto_UseLostFlareStarOnBosses { get; set; } = "Use Lost Flare Star on bosses";
+    public string ConfigWindow_Auto_UseLostFlareStarOnMobs { get; set; } = "Use Lost Flare Star on mobs";
+    public string ConfigWindow_Auto_UseLostAssassinationOnMobs { get; set; } = "Use Lost Assassination to kill non-boss targets";
+    public string ConfigWindow_Auto_LostReflectAutoRefresh { get; set; } = "Automatically refresh Lost Reflect before it expires";
+    public string ConfigWindow_Auto_LostAssassinationTimeToKill { get; set; } = "Expected TTK required to use Lost Assassination on target";
 
     public string ConfigWindow_Auto_HealthForAutoDefense { get; set; } = "HP Ratio about defense single of Tanks";
     public string ConfigWindow_Basic_SayHelloToUsers { get; set; } = "Say hello to the users of Rotation Solver.";

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -834,6 +834,14 @@ public partial class RotationConfigWindow
 
             new CheckBoxSearchPlugin(PluginConfigBool.AutoSpeedOutOfCombat),
         }),
+
+        new CheckBoxSearchPlugin(PluginConfigBool.UseLostActions, new ISearchable[] {
+            new CheckBoxSearchPlugin(PluginConfigBool.UseLostFlareStarOnBosses),
+            new CheckBoxSearchPlugin(PluginConfigBool.UseLostFlareStarOnMobs), 
+            new CheckBoxSearchPlugin(PluginConfigBool.UseLostAssassinationOnMobs,
+                new DragFloatSearchPlugin(PluginConfigFloat.LostAssassinationTimeToKill, 0.5f)),
+            new CheckBoxSearchPlugin(PluginConfigBool.LostReflectAutoRefresh)
+        }),
     };
     #endregion
 

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -836,7 +836,6 @@ public partial class RotationConfigWindow
         }),
 
         new CheckBoxSearchPlugin(PluginConfigBool.UseLostActions, new ISearchable[] {
-            new CheckBoxSearchPlugin(PluginConfigBool.UseLostFlareStarOnBosses),
             new CheckBoxSearchPlugin(PluginConfigBool.UseLostFlareStarOnMobs), 
             new CheckBoxSearchPlugin(PluginConfigBool.UseLostAssassinationOnMobs,
                 new DragFloatSearchPlugin(PluginConfigFloat.LostAssassinationTimeToKill, 0.5f)),


### PR DESCRIPTION
* Flare Star
  * Automatically used on bosses
  * Option to use on non-bosses
* Lost Assassination
  * Automatically used on bosses if player has Spirit of the Beast (grants Lost Font of Power)
  * Option to use from behind on non-bosses (chance to kill target)
* Lost Reflect
  * Option to auto-refresh
* Lost Rampage/Lost Burst
  * Automatically used as an interrupt skill
  * Automatically used on bosses with the corresponding magic/phys debuff

I also added definitions for Lost Font of Power and Banner of Honored Sacrifice, which are some of the meta DPS actions for Delubrum Reginae, but since they should be aligned with 2-minute burst windows, rotations should determine when to use them.

Also cleaned up a lot of other lost action definitions. They all used `StatusProvide` which is only correct for Lost Stoneskin II which is an AOE party buff. Every other lost action is either single target or targets hostiles, meaning `TargetStatus` should be used instead.