### PR TITLE
Option to force "All targets" behavior in solo duties

### DIFF
--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -280,6 +280,7 @@ public enum PluginConfigBool : byte
 
     [Default(true)] RaisePlayerByCasting,
     [Default(true)] RaiseBrinkOfDeath,
+    [Default(true)] TargetAllSolo,
     [Default(true)] AddEnemyListToHostile,
     [Default(false)] OnlyAttackInEnemyList,
     [Default(false)] UseTinctures,

--- a/RotationSolver.Basic/Configuration/Configs.cs
+++ b/RotationSolver.Basic/Configuration/Configs.cs
@@ -280,7 +280,7 @@ public enum PluginConfigBool : byte
 
     [Default(true)] RaisePlayerByCasting,
     [Default(true)] RaiseBrinkOfDeath,
-    [Default(true)] TargetAllSolo,
+    [Default(false)] TargetAllSolo,
     [Default(true)] AddEnemyListToHostile,
     [Default(false)] OnlyAttackInEnemyList,
     [Default(false)] UseTinctures,

--- a/RotationSolver.Basic/DataCenter.cs
+++ b/RotationSolver.Basic/DataCenter.cs
@@ -28,6 +28,18 @@ internal static class DataCenter
         }
     }
 
+    private static readonly HashSet<uint> _forayAreas = new() {
+        // Eureka zones
+        732, 763, 795, 827,
+
+        // Bozjan Southern Front (includes CLL)
+        920,
+        // Delubrum Reginae + Savage
+        936, 937,
+        // Zadnor (includes Dalriada)
+        975,
+    };
+
     internal static Queue<MapEffectData> MapEffects { get; } = new(64);
     internal static Queue<ObjectEffectData> ObjectEffects { get; } = new(64);
     internal static Queue<VfxNewData> VfxNewData { get; } = new(64);
@@ -116,6 +128,12 @@ internal static class DataCenter
         return keep;
     }
     public static HashSet<uint> DisabledActionSequencer { get; set; } = new HashSet<uint>();
+
+    internal static bool InSoloDuty() {
+        return Svc.Condition[ConditionFlag.BoundByDuty56]
+            && PartyMembers.Count(p => p.GetHealthRatio() > 0) == 1
+            && !_forayAreas.Contains(Territory.RowId);
+    }
 
     private static List<NextAct> NextActs = new();
     public static IAction ActionSequencerAction { private get; set; }

--- a/RotationSolver.Basic/Rotations/Basic/BLU_Base.cs
+++ b/RotationSolver.Basic/Rotations/Basic/BLU_Base.cs
@@ -904,7 +904,7 @@ public abstract class BLU_Base : CustomRotation
     public static IBLUAction BasicInstinct { get; } = new BLUAction(ActionID.BasicInstinct)
     {
         StatusProvide = new StatusID[] { StatusID.BasicInstinct },
-        ActionCheck = (b, m) => Svc.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.BoundByDuty56] && DataCenter.PartyMembers.Count(p => p.GetHealthRatio() > 0) == 1,
+        ActionCheck = (b, m) => DataCenter.InSoloDuty()
     };
 
     static IBaseAction AethericMimicry { get; } = new BaseAction(ActionID.AethericMimicry, ActionOption.Friendly)

--- a/RotationSolver/Localization/ConfigTranslation.cs
+++ b/RotationSolver/Localization/ConfigTranslation.cs
@@ -122,6 +122,7 @@ internal static class ConfigTranslation
         // target
         PluginConfigBool.AddEnemyListToHostile => LocalizationManager.RightLang.ConfigWindow_Param_AddEnemyListToHostile,
         PluginConfigBool.OnlyAttackInEnemyList => LocalizationManager.RightLang.ConfigWindow_Param_OnlyAttackInEnemyList,
+        PluginConfigBool.TargetAllSolo => LocalizationManager.RightLang.ConfigWindow_Param_TargetAllSolo,
         PluginConfigBool.ChooseAttackMark => LocalizationManager.RightLang.ConfigWindow_Param_ChooseAttackMark,
         PluginConfigBool.CanAttackMarkAOE => LocalizationManager.RightLang.ConfigWindow_Param_CanAttackMarkAOE,
         PluginConfigBool.FilterStopMark => LocalizationManager.RightLang.ConfigWindow_Param_FilterStopMark,

--- a/RotationSolver/Localization/Strings.cs
+++ b/RotationSolver/Localization/Strings.cs
@@ -220,6 +220,7 @@ internal class Strings
     public string ConfigWindow_Param_TargetToHostileType2 { get; set; } = "Previously engaged targets or all targets that are in range\n(engages on countdown timer and resets when out of combat)";
     public string ConfigWindow_Param_TargetToHostileType3 { get; set; } = "Previously engaged targets (engages on countdown timer)";
     public string ConfigWindow_Param_AddEnemyListToHostile { get; set; } = "Add enemy list to the hostile targets.";
+    public string ConfigWindow_Param_TargetAllSolo { get; set; } = "Force 'All targets' behavior while in solo duties.";
     public string ConfigWindow_Param_OnlyAttackInEnemyList { get; set; } = "Only attack the targets in enemy list.";
     public string ConfigWindow_Param_ChooseAttackMark { get; set; } = "Priority attack targets with attack markers";
     public string ConfigWindow_Param_CanAttackMarkAOE { get; set; } = "Allowed use of AoE to attack more mobs.";

--- a/RotationSolver/UI/RotationConfigWindow_Config.cs
+++ b/RotationSolver/UI/RotationConfigWindow_Config.cs
@@ -883,6 +883,7 @@ public partial class RotationConfigWindow
             PvPFilter = JobFilter.NoJob,
         },
 
+        new CheckBoxSearchPlugin(PluginConfigBool.TargetAllSolo),
         new CheckBoxSearchPlugin(PluginConfigBool.AddEnemyListToHostile, new CheckBoxSearchPlugin(PluginConfigBool.OnlyAttackInEnemyList)),
         new CheckBoxSearchPlugin(PluginConfigBool.FilterStopMark),
         new CheckBoxSearchPlugin(PluginConfigBool.ChooseAttackMark, new ISearchable[]

--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -183,7 +183,11 @@ internal static partial class TargetUpdater
             return tarFateId == 0 || tarFateId == fateId;
         });
 
-        if (type == TargetHostileType.AllTargetsCanAttack || Service.CountDownTime > 0 || (DataCenter.Territory?.IsPvpZone ?? false))
+        if (type == TargetHostileType.AllTargetsCanAttack
+            || Service.CountDownTime > 0
+            || (DataCenter.Territory?.IsPvpZone ?? false)
+            || Service.Config.GetValue(PluginConfigBool.TargetAllSolo) && DataCenter.InSoloDuty()
+            )
         {
             return allAttackableTargets;
         }


### PR DESCRIPTION
Minor tweak that saves a microscopic amount of time when running content unsynced. I have a habit of forgetting to change the target type back before queuing into other content which tends to annoy my party members.