### PR TITLE
fix enmity list offset

### DIFF
--- a/RotationSolver/Updaters/TargetUpdater.cs
+++ b/RotationSolver/Updaters/TargetUpdater.cs
@@ -225,7 +225,7 @@ internal static partial class TargetUpdater
         var addon = addons.FirstOrDefault();
         var enemy = (AddonEnemyList*)addon;
 
-        var numArray = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance()->GetUiModule()->GetRaptureAtkModule()->AtkModule.AtkArrayDataHolder.NumberArrays[19];
+        var numArray = FFXIVClientStructs.FFXIV.Client.System.Framework.Framework.Instance()->GetUiModule()->GetRaptureAtkModule()->AtkModule.AtkArrayDataHolder.NumberArrays[21];
         List<uint> list = new(enemy->EnemyCount);
         for (var i = 0; i < enemy->EnemyCount; i++)
         {


### PR DESCRIPTION
Fixes this feature: ![image](https://github.com/Jaksuhn/RotationSolver/assets/149614526/d9070970-3a01-4d70-94d5-7fb6d5928c04)

https://github.com/PunishXIV/PandorasBox/blob/1367eeeb7453c1572fdc5eda0ef9ba3b1a7b4625/PandorasBox/Features/Commands/ResetEnmity.cs#L65

19 isn't the right offset anymore, whatever is stored there is just an array of zeroes. 21 contains all the enemy object IDs.