### PR TITLE
Try to fix crashing during IsAlliance check

### DIFF
--- a/RotationSolver.Basic/Helpers/ObjectHelper.cs
+++ b/RotationSolver.Basic/Helpers/ObjectHelper.cs
@@ -75,9 +75,18 @@ public static class ObjectHelper
                 Svc.Log.Debug($"{nameof(IsAlliance)}: GameObject is null.");
                 return false;
             }
+            var objStruct = obj.Struct();
 
-            return ActionManager.CanUseActionOnTarget((uint)ActionID.Cure, obj.Struct())
-                || ActionManager.CanUseActionOnTarget((uint)ActionID.Raise1, obj.Struct());
+            if (objStruct == null)
+            {
+                Svc.Log.Debug($"{nameof(IsAlliance)}: GameObject struct is null");
+                return false;
+            }
+            else
+            {
+                return ActionManager.CanUseActionOnTarget((uint)ActionID.Cure, objStruct)
+                    || ActionManager.CanUseActionOnTarget((uint)ActionID.Raise1, objStruct);
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Updates ECommons to latest commit and slightly reworks IsAlliance() to try and prevent crashing. We now pull the struct only once and check if it's valid before passing it to CanUseActionOnTarget().